### PR TITLE
Refactor token handling and update README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # wit-tool-prototype
+
+## Tokenization
+Extracts and displays all named tokens from a WIT file using treesitter
+
+Usage: cargo run <path-to-file.wit> tokens
+Output: For each named token, the tool prints the kind of token and the corresponding text from the file


### PR DESCRIPTION
Improve code readability by refactoring token handling into a separate function. Update the README to include details on tokenization and usage instructions.